### PR TITLE
Change authentication URL to login.microsoftonline.com

### DIFF
--- a/app/torii-providers/azure-oauth2.js
+++ b/app/torii-providers/azure-oauth2.js
@@ -1,33 +1,29 @@
 import Oauth2 from 'torii/providers/oauth2-code';
-import {configurable} from 'torii/configuration';
+import { configurable } from 'torii/configuration';
 
 /**
- * This class implements authentication against Azure
- * using the OAuth2 authorization flow in a popup window.
+ * This class implements authentication against Azure using the OAuth2
+ * authorization flow in a popup window.
  * @class
  */
-var AzureOauth2 = Oauth2.extend({
-  name:       'azure-oauth2',
-  baseUrl:    'https://login.windows.net/common/oauth2/authorize',
+export default Oauth2.extend({
+  name: 'azure-oauth2',
+  baseUrl: 'https://login.microsoftonline.com/common/oauth2/authorize',
 
   // additional url params that this provider requires
   requiredUrlParams: ['state'],
 
   responseParams: ['code','session_state','state'],
 
-  state: configurable('state', function(){
-    // A hack that allows redirectUri to be configurable
-    // but default to the superclass
-    return 'STATE';
+  state: configurable('state', function() {
+    // A hack that allows redirectUri to be configurable but default to the
+    // superclass
+    return this._super();
   }),
 
-  response_type: "code",
-
-  redirectUri: configurable('redirectUri', function(){
-    // A hack that allows redirectUri to be configurable
-    // but default to the superclass
+  redirectUri: configurable('redirectUri', function() {
+    // A hack that allows redirectUri to be configurable but default to the
+    // superclass
     return this._super();
   })
 });
-
-export default AzureOauth2;


### PR DESCRIPTION
Microsoft updated their authentication domain to login.microsoftonline.com (see the [blog post](https://cloudblogs.microsoft.com/enterprisemobility/2015/03/06/simplifying-our-azure-ad-authentication-flows/) and [current documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols-oauth-code)). This PR makes that change.