### PR TITLE
Replace redirect_uri with redirectUri

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ module.exports = function(environment) {
       providers: {
         'azure-oauth2': {
           apiKey: 'AZURE APP CLIENT ID GOES HERE',
-          redirect_uri: "APP URI GOES HERE",
+          redirectUri: "APP URI GOES HERE",
           state: "STATE" // For CSRF, should be random & unguessable
         }
       }


### PR DESCRIPTION
Not *certain* it's required, but best to stick to camelCase as a standard.